### PR TITLE
Fix caching in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,19 +32,17 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: "Install Nix ❄️"
-        uses: cachix/install-nix-action@v26
+        uses: cachix/install-nix-action@v27
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: "Install Cachix ❄️"
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v15
         with:
           name: zackartz
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-         
-        
+          signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
+
       - name: "Build NixOS config ❄️"
-        env:
-          CACHIX_SIGNING_KEY: "${{ secrets.CACHIX_SIGNING_KEY }}"
         run: |
           nix build .\#nixosConfigurations."earth".config.system.build.toplevel 


### PR DESCRIPTION
Hey, @zackartz! I work for Cachix. I noticed a lot of errors in our telemetry coming from your cache. It looks like the signing key isn't being use to sign the uploaded store paths. This should now cache your NixOS builds (as long as the key is correct), so your CI runs should complete really fast.

I'll add an update to cachix-action to catch this type of configuration error much earlier in the future. Cheers!
